### PR TITLE
Ratelimitd

### DIFF
--- a/health.d/smtp.conf
+++ b/health.d/smtp.conf
@@ -8,3 +8,11 @@ families: *
     warn: $this > 60
     crit: $this > 120
       to: silent
+
+   alarm: ratelimit
+      on: qmail.ratelimitspp_events
+      os: linux
+  lookup: sum -1m of ratelimited
+   every: 30s
+    crit: $this > 10
+      to: sysadmin

--- a/smtp.c
+++ b/smtp.c
@@ -250,7 +250,8 @@ postprocess_data(struct smtp_statistics * data) {
 
 	aggregated_ratelimtspp.conn_timeout += data->ratelimitspp.conn_timeout;
 	aggregated_ratelimtspp.error += data->ratelimitspp.error;
-	aggregated_ratelimtspp.ratelimited += data->ratelimitspp.ratelimited;
+	if (data->ratelimitspp.ratelimited)
+		aggregated_ratelimtspp.ratelimited = 1;
 }
 
 static


### PR DESCRIPTION
_ratelimited_ metric in the chart _qmail.ratelimitspp_events_ will only present values 0 if no records collected or 1 if any record collected.
Corresponding alarm set.